### PR TITLE
Fix GitHub issue #2: REPL does not work with #lang datalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Racket compiled files
 compiled/
+# Generated documentation
+/doc/
 
 # common backups, autosaves, lock files, OS meta-files
 *~

--- a/lang/reader.rkt
+++ b/lang/reader.rkt
@@ -18,14 +18,16 @@
              [else (default key defval)]))
   (require datalog/parse
            datalog/private/compiler)
-
+  
   (define (call-with-intro thunk)
     (define intro (make-syntax-introducer #t))
     (parameterize ([current-datalog-introducer intro])
       (intro (thunk))))
   
   (define (this-read-syntax [src #f] [in (current-input-port)])
-    (quasisyntax/loc src
-      #,(compile-program
-         (parameterize ([current-source-name src])
-           (parse-program in))))))
+    ((make-syntax-delta-introducer #'here #f)
+     (quasisyntax/loc src
+       #,(compile-program
+          (parameterize ([current-source-name src])
+            (parse-program in))))
+     'remove)))


### PR DESCRIPTION
I used `((make-syntax-delta-introducer #'x) (quasisyntax/loc …))`, where `x` is not a pattern variable to remove the extraneous scopes added by `quasisyntax/loc`. It seems to work fine now.

I also added the `/doc/` folder to `.gitignore`, as `raco pkg install` generates it.