### PR TITLE
Pass arguments in right order in `test-lexer`.

### DIFF
--- a/tests/private/lex.rkt
+++ b/tests/private/lex.rkt
@@ -9,8 +9,8 @@
   (define pv (dlexer (open-input-string str)))
   (define v (position-token-token pv))
   (test-equal? (format "lexer: ~a: <~a,~a>" str tok-name tok-value)
-               (cons tok-name tok-value)
-               (cons (token-name v) (token-value v))))
+               (cons (token-name v) (token-value v))
+               (cons tok-name tok-value)))
 
 (define lex-tests
   (test-suite


### PR DESCRIPTION
Pass `actual` and `expected` in the right order, otherwise the error
messages don't make sense when a test fails.

I realize it's a very minor thing but I figured I'd PR it anyway so it doesn't trip up the next guy.  I had a quick look at other test-equal? call sites but they all looked okay.