### PR TITLE
Compiler no longer assumes constants are symbols (fixes #8).

### DIFF
--- a/private/compiler.rkt
+++ b/private/compiler.rkt
@@ -64,11 +64,11 @@
   (match-lambda
     [(variable srcloc sym)
      (sym->original-syntax sym srcloc)]
-    [(constant srcloc sym)
-     (sym->original-syntax sym srcloc)]))
+    [(constant srcloc cnst)
+     (sym->original-syntax cnst srcloc)]))
 
-(define (sym->original-syntax sym srcloc)
-  (define p (open-input-string (symbol->string sym)))
+(define (sym->original-syntax cnst srcloc)
+  (define p (open-input-string (format "~s" cnst)))
   (port-count-lines! p)
   (match-define (list source-name line column position span) srcloc)
   (set-port-next-location! p line column position)

--- a/tests/examples/hello.rkt
+++ b/tests/examples/hello.rkt
@@ -1,0 +1,4 @@
+#lang datalog
+% hello world string
+greeting("Hello, world!").
+greeting(G)?

--- a/tests/examples/hello.txt
+++ b/tests/examples/hello.txt
@@ -1,0 +1,1 @@
+greeting("Hello, world!").


### PR DESCRIPTION
`compile-term` assumed that `constant-value` always produces a symbol. Thus, `symbol->string` caused an error.

I changed it to `(format "~s" cnst)` so that it supports most data that can be read back with `read-syntax`. 