### PR TITLE
support external queries in `#lang datalog`

### DIFF
--- a/ast.rkt
+++ b/ast.rkt
@@ -77,8 +77,9 @@
 (define-struct assertion (srcloc clause) #:prefab)
 (define-struct retraction (srcloc clause) #:prefab)
 (define-struct query (srcloc question) #:prefab)
+(define-struct requirement (srcloc lib) #:prefab)
 
-(define statement/c (or/c assertion? retraction? query?))
+(define statement/c (or/c assertion? retraction? query? requirement?))
 (define program/c (listof statement/c))
 
 (provide/contract
@@ -95,7 +96,7 @@
  [term/c contract?]
  [term-equal? (term/c term/c . -> . boolean?)]
  [struct literal ([srcloc srcloc/c]
-                  [predicate (or/c predicate-sym? string? symbol?)]
+                  [predicate (or/c predicate-sym? string? symbol? number? boolean?)]
                   [terms (listof term/c)])]
  [literal-equal? (literal? literal? . -> . boolean?)]
  [struct external ([srcloc srcloc/c]
@@ -116,5 +117,7 @@
                      [clause clause?])]
  [struct query ([srcloc srcloc/c]
                 [question question/c])]
+ [struct requirement ([srcloc srcloc/c]
+                      [lib string?])]
  [statement/c contract?]
  [program/c contract?])

--- a/private/compiler.rkt
+++ b/private/compiler.rkt
@@ -33,7 +33,11 @@
     [(query srcloc l)
      (define srcstx (datum->syntax #f 'x srcloc))
      (quasisyntax/loc srcstx
-       (#,(intro #'?) #,(compile-literal l)))]))
+       (#,(intro #'?) #,(compile-literal l)))]
+    [(requirement srcloc l)
+     (define srcstx (datum->syntax #f 'x srcloc))
+     (quasisyntax/loc srcstx
+       (#,(intro #'require) #,(datum->syntax #f (string->symbol l))))]))
 
 (define compile-clause
   (match-lambda
@@ -58,7 +62,14 @@
                                                 (predicate-sym-srcloc pred))
                           pred))
      (quasisyntax/loc srcstx
-       (#,pred-stx #,@(map compile-term ts)))]))
+       (#,pred-stx #,@(map compile-term ts)))]
+    [(external srcloc predicate-sym predicate arg-terms ans-terms)
+     (define srcstx (datum->syntax #f 'x srcloc))
+     (quasisyntax/loc srcstx
+       (#,(datum->syntax #f predicate-sym)
+        #,@(map compile-term arg-terms)
+        #,(intro #':-)
+        #,@(map compile-term ans-terms)))]))
 
 (define compile-term
   (match-lambda

--- a/tests/parse.rkt
+++ b/tests/parse.rkt
@@ -20,15 +20,19 @@
     (test-literal-parse "parent(john, douglas)"
                         (make-literal #f 'parent (list (make-constant #f 'john) (make-constant #f 'douglas))))
     (test-literal-parse "1 = 2"
-                        (make-literal #f '= (list (make-constant #f '|1|) (make-constant #f '|2|))))
-    (test-literal-parse "1 != 2"
-                        (make-literal #f '!= (list (make-constant #f '|1|) (make-constant #f '|2|))))
+                        (make-literal #f '= (list (make-constant #f 1) (make-constant #f 2))))
+    (test-literal-parse "1 != -2"
+                        (make-literal #f '!= (list (make-constant #f 1) (make-constant #f -2))))
+    (test-literal-parse "01 != 2"
+                        (make-literal #f '!= (list (make-constant #f '|01|) (make-constant #f 2))))
+    (test-literal-parse "true != false"
+                        (make-literal #f '!= (list (make-constant #f #t) (make-constant #f #f))))
     (test-literal-parse "zero-arity-literal"
                         (make-literal #f 'zero-arity-literal empty))
     (test-literal-parse "zero-arity-literal()"
                         (make-literal #f 'zero-arity-literal empty))
     (test-literal-parse "\"=\"(3,3)"
-                        (make-literal #f "=" (list (make-constant #f '|3|) (make-constant #f '|3|))))
+                        (make-literal #f "=" (list (make-constant #f 3) (make-constant #f 3))))
     (test-literal-parse "\"\"(-0-0-0,&&&,***,\"\00\")"
                         (make-literal #f "" (list (make-constant #f '-0-0-0)
                                                   (make-constant #f '&&&)


### PR DESCRIPTION
Support for external queries makes `#lang datalog` better for demos.

Supporting externals in the non-S-expression syntax requires adding a
way to import bindings and adding a way to call externals (with the
caveat that externals can break termination). Externals work better if
the obvious subset of literals are interpreted as integers and
booleans.

This patch makes those additions without adding new keywords, and it
should not break any existing `#lang datalog` programs. It could
change the interpretation of existing `#lang datalog` programs to use
numbers and booleans in place of symbols, but the syntax of numbers is
constrained so that formerly distinct symbols will not be collapsed to
the same number or boolean.