### PR TITLE
Add some features.

### DIFF
--- a/scribblings/racket.scrbl
+++ b/scribblings/racket.scrbl
@@ -49,12 +49,12 @@ The Datalog database can be directly used by Racket programs through this API.
                           (parent A B)))
                    (! (:- (ancestor A B)
                           (parent A C)
-                          (= D C) 
+                          (= D C)
                           (ancestor D B))))
- 
+
           (datalog family
                    (? (ancestor A B)))
- 
+
           (let ([x 'joseph2])
             (datalog family
                      (? (parent x X))))
@@ -70,8 +70,8 @@ The Datalog database can be directly used by Racket programs through this API.
 
 @defproc[(make-theory) theory/c]{ Creates a theory for use with @racket[datalog]. }
 
-@defproc[(write-theory [t theory/c]) void]{ Writes a theory to the current output port. Source location information is lost. }
-@defproc[(read-theory) theory/c]{ Reads a theory from the current input port. }
+@defproc[(write-theory [t theory/c] [out output-port? (current-output-port)]) void?]{ Writes @racket[t] to @racket[out]. Source location information is lost. }
+@defproc[(read-theory [in input-port? (current-input-port)]) theory/c]{ Reads and returns a theory from @racket[in]. }
 
 @defform[(datalog thy-expr
                   stmt ...)
@@ -79,7 +79,7 @@ The Datalog database can be directly used by Racket programs through this API.
 
 @defform[(datalog! thy-expr
                   stmt ...)
-         #:contracts ([thy-expr theory/c])]{ Executes the statements on the theory given by @racket[thy-expr]. Prints the answers to every query in the list of statements. Returns @racket[(void)]. }     
+         #:contracts ([thy-expr theory/c])]{ Executes the statements on the theory given by @racket[thy-expr]. Prints the answers to every query in the list of statements. Returns @racket[(void)]. }
 
 Statements are either assertions, retractions, or queries.
 

--- a/serialize.rkt
+++ b/serialize.rkt
@@ -21,18 +21,12 @@
      #f]
     [x x]))
 
-(define (write-theory t)
-  (write (remove-paths t)))
+(define (write-theory t [out (current-output-port)])
+  (write (remove-paths t) out))
 
-(define (hash->hash! ht)
-  (define ht! (make-hash))
-  (for ([(k v) (in-hash ht)])
-    (hash-set! ht! k v))
-  ht!)
-
-(define (read-theory)
-  (hash->hash! (read)))
+(define (read-theory [in (current-input-port)])
+  (hash-copy (read in)))
 
 (provide/contract
- [write-theory (-> theory/c void)]
- [read-theory (-> theory/c)])
+ [write-theory (->* (theory/c) (output-port?) void?)]
+ [read-theory (->* () (input-port?) theory/c)])

--- a/stx.rkt
+++ b/stx.rkt
@@ -108,18 +108,16 @@
                              ([stx0 (in-list stx*)])
                      (for/fold ([vars vars0])
                                ([stx (in-list (syntax->list (parser stx0)))])
-                       (cond
-                         [(syntax-parse stx
-                            [sym:id
-                             (and
-                              (not (identifier-binding #'sym 0))
-                              (datalog-variable-symbol? (syntax->datum #'sym))
-                              (not (findf (curry bound-identifier=? #'sym)
-                                          vars))
-                              #'sym)]
-                            [sym:expr #f])
-                          => (λ (var) (cons var vars))]
-                         [else vars]))))))
+                       (if (syntax-parse stx
+                             [sym:id
+                              (and
+                               (not (identifier-binding #'sym 0))
+                               (datalog-variable-symbol? (syntax->datum #'sym))
+                               (not (findf (curry bound-identifier=? #'sym)
+                                           vars)))]
+                             [sym:expr #f])
+                           (cons stx vars)
+                           vars))))))
              (define head-vars (datalog-literal-variables #'head))
              (define body-vars (apply datalog-literal-variables (syntax->list #'(body ...))))
              (define body-vars-in-head

--- a/stx.rkt
+++ b/stx.rkt
@@ -104,20 +104,19 @@
                       #'(e ...)]))
 
                  (λ stx*
-                   (for/fold ([vars0 '()])
-                             ([stx0 (in-list stx*)])
-                     (for/fold ([vars vars0])
-                               ([stx (in-list (syntax->list (parser stx0)))])
-                       (if (syntax-parse stx
-                             [sym:id
-                              (and
-                               (not (identifier-binding #'sym 0))
-                               (datalog-variable-symbol? (syntax->datum #'sym))
-                               (not (findf (curry bound-identifier=? #'sym)
-                                           vars)))]
-                             [sym:expr #f])
-                           (cons stx vars)
-                           vars))))))
+                   (for*/fold ([vars '()])
+                              ([stx0 (in-list stx*)]
+                               [stx  (in-list (syntax->list (parser stx0)))])
+                     (if (syntax-parse stx
+                           [sym:id
+                            (and
+                             (not (identifier-binding #'sym 0))
+                             (datalog-variable-symbol? (syntax->datum #'sym))
+                             (not (findf (curry bound-identifier=? #'sym)
+                                         vars)))]
+                           [sym:expr #f])
+                         (cons stx vars)
+                         vars)))))
              (define head-vars (datalog-literal-variables #'head))
              (define body-vars (apply datalog-literal-variables (syntax->list #'(body ...))))
              (define body-vars-in-head

--- a/stx.rkt
+++ b/stx.rkt
@@ -104,16 +104,15 @@
                       #'(e ...)]))
 
                  (λ stx*
-                   (for*/fold ([vars '()])
+                   (for*/fold ([vars '()]
+                               #:result (remove-duplicates vars bound-identifier=?))
                               ([stx0 (in-list stx*)]
                                [stx  (in-list (syntax->list (parser stx0)))])
                      (if (syntax-parse stx
                            [sym:id
                             (and
                              (not (identifier-binding #'sym 0))
-                             (datalog-variable-symbol? (syntax->datum #'sym))
-                             (not (findf (curry bound-identifier=? #'sym)
-                                         vars)))]
+                             (datalog-variable-symbol? (syntax->datum #'sym)))]
                            [sym:expr #f])
                          (cons stx vars)
                          vars)))))

--- a/stx.rkt
+++ b/stx.rkt
@@ -10,7 +10,8 @@
          datalog/eval)
 
 (begin-for-syntax
-  (define (datalog-variable-string? s)
+  (define (datalog-variable-symbol? sym)
+    (define s (symbol->string sym))
     (and (< 0 (string-length s))
          (char-upper-case? (string-ref s 0)))))
 
@@ -24,7 +25,8 @@
   (raise-syntax-error '? "only allowed inside datalog" stx))
 
 (define (->substitutions sel ls)
-  (if (void? ls) empty
+  (if (void? ls)
+      empty
       (map sel ls)))
 
 (define literal->sexp
@@ -41,8 +43,7 @@
 
 (define term->datum
   (match-lambda
-    [(constant _ v)
-     v]))
+    [(constant _ v) v]))
 
 (define-syntax (datalog stx)
   (syntax-case stx ()
@@ -65,81 +66,79 @@
          ...))]))
 
 (define-syntax (datalog-stmt stx)
-  (syntax-parse 
-   stx
-   #:literals (! ~ ?)
-   [(_ (~and tstx (! c)))
-    (quasisyntax/loc #'tstx
-      (assertion #,(srcloc-list #'tstx) (datalog-clause c)))]
-   [(_ (~and tstx (~ c)))
-    (quasisyntax/loc #'tstx
-      (retraction #,(srcloc-list #'tstx) (datalog-clause c)))]
-   [(_ (~and tstx (? l)))
-    (quasisyntax/loc #'tstx
-      (query #,(srcloc-list #'tstx) (datalog-literal/ref l)))]))
+  (syntax-parse stx
+    #:literals (! ~ ?)
+    [(_ (~and tstx (! c)))
+     (quasisyntax/loc #'tstx
+       (assertion #,(srcloc-list #'tstx) (datalog-clause c)))]
+    [(_ (~and tstx (~ c)))
+     (quasisyntax/loc #'tstx
+       (retraction #,(srcloc-list #'tstx) (datalog-clause c)))]
+    [(_ (~and tstx (? l)))
+     (quasisyntax/loc #'tstx
+       (query #,(srcloc-list #'tstx) (datalog-literal/ref l)))]))
 
 (define-syntax (datalog-stmt-var-selector stx)
-  (syntax-parse 
-   stx
-   #:literals (! ~ ?)
-   [(_ (~and tstx (! c)))
-    (quasisyntax/loc #'tstx (λ (l) (hasheq)))]
-   [(_ (~and tstx (~ c)))
-    (quasisyntax/loc #'tstx (λ (l) (hasheq)))]
-   [(_ (~and tstx (? l)))
-    (quasisyntax/loc #'tstx (datalog-literal-var-selector l))]))
+  (syntax-parse stx
+    #:literals (! ~ ?)
+    [(_ (~and tstx (! c)))
+     (quasisyntax/loc #'tstx (λ (l) (hasheq)))]
+    [(_ (~and tstx (~ c)))
+     (quasisyntax/loc #'tstx (λ (l) (hasheq)))]
+    [(_ (~and tstx (? l)))
+     (quasisyntax/loc #'tstx (datalog-literal-var-selector l))]))
 
 (define-syntax (datalog-clause stx)
-  (syntax-parse 
-   stx
-   #:literals (:-)
-   [(_ (~and tstx (:- head body ...)))
-    (local [(define (datalog-literal-variables stx)
-              (syntax-parse 
-               stx
-               #:literals (:-)
-               [sym:id
-                empty]
-               [(~and tstx (sym:id arg ... :- ans ...))
-                (append-map datalog-term-variables
-                            (syntax->list #'(arg ... ans ...)))]
-               [(~and tstx (sym:id e ...))
-                (append-map datalog-term-variables
-                            (syntax->list #'(e ...)))]))
-            (define (datalog-term-variables stx)
-              (syntax-parse 
-               stx
-               [sym:id
-                (cond
-                  [(identifier-binding #'sym 0)
-                   empty]
-                  [(datalog-variable-string? (symbol->string (syntax->datum #'sym)))
-                   (list #'sym)]
-                  [else
-                   empty])]
-               [sym:expr
-                empty]))
-            (define head-vars (datalog-literal-variables #'head))
-            (define body-vars 
-              (append-map datalog-literal-variables (syntax->list #'(body ...))))
-            (define body-vars-in-head
-              (filter
-               (λ (bv)
-                 (findf (curry bound-identifier=? bv)
-                        head-vars))
-               body-vars))
-            (define fake-lam
-              (quasisyntax/loc #'tstx
-                (lambda #,head-vars
-                  (void #,@body-vars-in-head))))]
-      (syntax-local-lift-expression
-       fake-lam))
-    (quasisyntax/loc #'tstx
-      (clause #,(srcloc-list #'tstx) (datalog-literal/bind head) 
-              (list (datalog-literal/ref body) ...)))]
-   [(_ e)
-    (quasisyntax/loc #'e
-      (clause #,(srcloc-list #'e) (datalog-literal/bind e) empty))]))
+  (syntax-parse stx
+    #:literals (:-)
+    [(_ (~and tstx (:- head body ...)))
+     (local [(define datalog-literal-variables
+               (let ()
+                 (define parser
+                   (syntax-parser
+                     #:literals (:-)
+                     [sym:id empty]
+                     [(~and tstx (sym:id arg ... :- ans ...))
+                      #'(arg ... ans ...)]
+                     [(~and tstx (sym:id e ...))
+                      #'(e ...)]))
+
+                 (λ stx*
+                   (for/fold ([vars0 '()])
+                             ([stx0 (in-list stx*)])
+                     (for/fold ([vars vars0])
+                               ([stx (in-list (syntax->list (parser stx0)))])
+                       (cond
+                         [(syntax-parse stx
+                            [sym:id
+                             (and
+                              (not (identifier-binding #'sym 0))
+                              (datalog-variable-symbol? (syntax->datum #'sym))
+                              (not (findf (curry bound-identifier=? #'sym)
+                                          vars))
+                              #'sym)]
+                            [sym:expr #f])
+                          => (λ (var) (cons var vars))]
+                         [else vars]))))))
+             (define head-vars (datalog-literal-variables #'head))
+             (define body-vars (apply datalog-literal-variables (syntax->list #'(body ...))))
+             (define body-vars-in-head
+               (filter
+                (λ (bv)
+                  (findf (curry bound-identifier=? bv)
+                         head-vars))
+                body-vars))
+             (define fake-lam
+               (quasisyntax/loc #'tstx
+                 (lambda #,head-vars
+                   (void #,@body-vars-in-head))))]
+       (syntax-local-lift-expression fake-lam))
+     (quasisyntax/loc #'tstx
+       (clause #,(srcloc-list #'tstx) (datalog-literal/bind head)
+               (list (datalog-literal/ref body) ...)))]
+    [(_ e)
+     (quasisyntax/loc #'e
+       (clause #,(srcloc-list #'e) (datalog-literal/bind e) empty))]))
 
 (define-syntax (datalog-literal/bind stx) (datalog-literal/b stx #t))
 (define-syntax (datalog-literal/ref stx) (datalog-literal/b stx #f))
@@ -154,11 +153,10 @@
              #:attr ref #'sym
              #:attr val #'sym))
   (define (datalog-literal/b stx binding?)
-    (syntax-parse 
-        stx
+    (syntax-parse stx
       #:literals (:-)
       [(_ sym:table-id)
-       (syntax-property 
+       (syntax-property
         (quasisyntax/loc #'sym
           (literal #,(srcloc-list #'sym) sym.ref empty))
         (if binding? 'disappeared-binding 'disappeared-use)
@@ -171,67 +169,65 @@
       [(_ (~and tstx (sym:table-id e ...)))
        (syntax-property
         (quasisyntax/loc #'tstx
-          (literal #,(srcloc-list #'tstx) sym.ref 
+          (literal #,(srcloc-list #'tstx) sym.ref
                    (list (datalog-term e)
                          ...)))
         (if binding? 'disappeared-binding 'disappeared-use)
         (syntax-local-introduce #'sym))])))
 
 (define-syntax (datalog-literal-var-selector stx)
-  (syntax-parse 
-   stx
-   #:literals (:-)
-   [(_ sym:table-id)
-    (quasisyntax/loc #'sym (λ (l) (hasheq)))]
-   [(_ (~and tstx (sym:table-id arg ... :- ans ...)))
-    (quasisyntax/loc #'tstx 
-      (match-lambda
-        [(external _srcloc _predsym _pred args anss)
-         (terms->hasheq (list (datalog-term arg) ...
-                              (datalog-term ans) ...)
-                        (append args anss))]))]
-   [(_ (~and tstx (sym:table-id e ...)))
-    (quasisyntax/loc #'tstx
-      (match-lambda
-        [(literal _srcloc _predsym ts)
-         (terms->hasheq (list (datalog-term e) ...)
-                        ts)]))]))
+  (syntax-parse stx
+    #:literals (:-)
+    [(_ sym:table-id)
+     (quasisyntax/loc #'sym (λ (l) (hasheq)))]
+    [(_ (~and tstx (sym:table-id arg ... :- ans ...)))
+     (quasisyntax/loc #'tstx
+       (match-lambda
+         [(external _srcloc _predsym _pred args anss)
+          (terms->hasheq (list (datalog-term arg) ...
+                               (datalog-term ans) ...)
+                         (append args anss))]))]
+    [(_ (~and tstx (sym:table-id e ...)))
+     (quasisyntax/loc #'tstx
+       (match-lambda
+         [(literal _srcloc _predsym ts)
+          (terms->hasheq (list (datalog-term e) ...)
+                         ts)]))]))
 
 (define (terms->hasheq src-ts res-ts)
   (for/fold ([h (hasheq)])
-    ([src (in-list src-ts)]
-     [res (in-list res-ts)])
+            ([src (in-list src-ts)]
+             [res (in-list res-ts)])
     (if (variable? src)
         (hash-set h (variable-sym src) (constant-value res))
         h)))
 
 (define-syntax (datalog-term stx)
-  (syntax-parse 
-   stx
-   #:literals (unsyntax)
-   [(_ sym:id)
-    (cond
-      [(identifier-binding #'sym 0)
-       (quasisyntax/loc #'sym
-         (constant #,(srcloc-list #'sym) sym))]
-      [(datalog-variable-string? (symbol->string (syntax->datum #'sym)))
-       (quasisyntax/loc #'sym
-         (variable #,(srcloc-list #'sym) 'sym))]
-      [else
-       (quasisyntax/loc #'sym
-         (constant #,(srcloc-list #'sym) 'sym))])]
-   [(_ (unsyntax sym:expr))
-    (quasisyntax/loc #'sym
-      (constant #,(srcloc-list #'sym) sym))]
-   [(_ sym:expr)
-    (quasisyntax/loc #'sym
-      (constant #,(srcloc-list #'sym) sym))]))
+  (syntax-parse stx
+    #:literals (unsyntax)
+    [(_ sym:id)
+     (cond
+       [(identifier-binding #'sym 0)
+        (quasisyntax/loc #'sym
+          (constant #,(srcloc-list #'sym) sym))]
+       [(datalog-variable-symbol? (syntax->datum #'sym))
+        (quasisyntax/loc #'sym
+          (variable #,(srcloc-list #'sym) 'sym))]
+       [else
+        (quasisyntax/loc #'sym
+          (constant #,(srcloc-list #'sym) 'sym))])]
+    [(_ (unsyntax sym:expr))
+     (quasisyntax/loc #'sym
+       (constant #,(srcloc-list #'sym) sym))]
+    [(_ sym:expr)
+     (quasisyntax/loc #'sym
+       (constant #,(srcloc-list #'sym) sym))]))
 
 (define-for-syntax (srcloc-list stx)
   (define src (syntax-source stx))
   `(list ,(if (path? src)
-             `(bytes->path ,(path->bytes src))
-             `',src)
+              `(bytes->path ,(path->bytes src))
+              `',src)
          ',(syntax-line stx)
          ',(syntax-column stx)
          ',(syntax-position stx)

--- a/tests/examples/idpath.rkt
+++ b/tests/examples/idpath.rkt
@@ -1,0 +1,17 @@
+#lang datalog
+% path test from Chen & Warren
+edge(a, b). edge(b, c). edge(c, d). edge(d, a).
+
+node(X) :- edge(X, Y).
+node(Y) :- edge(X, Y).
+
+edge(X, X) :- node(X).
+
+path(X, X) :- node(X).
+path(X, Y) :- edge(X, Y).
+path(X, Y) :- edge(X, Z), path(Z, Y).
+path(X, Y) :- path(X, Z), edge(Z, Y).
+
+node(X)?
+edge(X, Y)?
+path(X, Y)?

--- a/tests/examples/idpath.txt
+++ b/tests/examples/idpath.txt
@@ -1,0 +1,28 @@
+node(b).
+node(c).
+node(d).
+node(a).
+edge(a, b).
+edge(b, b).
+edge(b, c).
+edge(c, c).
+edge(c, d).
+edge(a, a).
+edge(d, d).
+edge(d, a).
+path(b, a).
+path(b, d).
+path(b, c).
+path(b, b).
+path(c, b).
+path(c, a).
+path(c, d).
+path(c, c).
+path(a, d).
+path(a, c).
+path(a, b).
+path(a, a).
+path(d, c).
+path(d, b).
+path(d, a).
+path(d, d).

--- a/tests/paren-examples/idpath.rkt
+++ b/tests/paren-examples/idpath.rkt
@@ -1,0 +1,29 @@
+#lang datalog/sexp
+; path test from Chen & Warren
+(! (edge a b))
+(! (edge b c))
+(! (edge c d))
+(! (edge d a))
+
+(! (:- (node X)
+       (edge X Y)))
+(! (:- (node Y)
+       (edge X Y)))
+
+(! (:- (edge X X)
+       (node X)))
+
+(! (:- (path X X)
+       (node X)))
+(! (:- (path X Y)
+       (edge X Y)))
+(! (:- (path X Y)
+       (edge X Z)
+       (path Z Y)))
+(! (:- (path X Y)
+       (path X Z)
+       (edge Z Y)))
+
+(? (node X))
+(? (edge X Y))
+(? (path X Y))

--- a/tests/paren-examples/idpath.txt
+++ b/tests/paren-examples/idpath.txt
@@ -1,0 +1,28 @@
+node(b).
+node(c).
+node(d).
+node(a).
+edge(a, b).
+edge(b, b).
+edge(b, c).
+edge(c, c).
+edge(c, d).
+edge(a, a).
+edge(d, d).
+edge(d, a).
+path(b, a).
+path(b, d).
+path(b, c).
+path(b, b).
+path(c, b).
+path(c, a).
+path(c, d).
+path(c, c).
+path(a, d).
+path(a, c).
+path(a, b).
+path(a, a).
+path(d, c).
+path(d, b).
+path(d, a).
+path(d, d).


### PR DESCRIPTION
This PR mainly makes the following changes:

1. Add `port` parameter to `read-theory` and `write-theory`.
2. Use `void?` instead of `void` to check the return value of `write-theory`.
3. Modify the definition of `datalog-literal-variables`, so that it can accept any number of `stx` and return the `variable`s that are not repeated in these `stx`s. In this way, the `head vars` of the `conditional clause` can accept multiple same `variable`s as parameters (see the test file `idpath.rkt`).
